### PR TITLE
Multiple Improvments/Bug Fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ In comparison to CloudFormation StackSets, it offers the following additional fu
 * Start installations of different CloudFormation stacks from one single "master" CloudFormation stack.
 
 In comparison to CloudFormation nested Stacks, it offers the following additional functionalities:
-* Cross-Region
+* The solution works Cross-Region and
 * Cross-Account
 
 ![CrossStack Architecture](_images/architecture.drawio.png)
@@ -40,7 +40,7 @@ Properties:
   CfnCapabilities:
   - Array
   CfnParameters:
-    StackParameter
+    StackParameters
   CfnStackName: String
   CfnTemplate: String
   CfnTemplateUrl: String
@@ -48,7 +48,7 @@ Properties:
   Region: String
 ```
 
-StackParameter Object
+StackParameters Object
 ```yml
 ParameterKey1: ParamterValue1
 ...

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Properties:
   CfnCapabilities:
   - Array
   CfnParameters:
-    Parameter
+    StackParameter
   CfnStackName: String
   CfnTemplate: String
   CfnTemplateUrl: String
@@ -48,9 +48,11 @@ Properties:
   Region: String
 ```
 
-Parameter Object
+StackParameter Object
 ```yml
-ParameterKey: ParamterValue
+ParameterKey1: ParamterValue1
+...
+ParameterKeyN: ParameterValueN
 ```
 
 ## Properties

--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@ In comparison to CloudFormation StackSets, it offers the following additional fu
 * Use these Outputs as input for other Resources and configure follow-up Resources accordingly.
 * Start installations of different CloudFormation stacks from one single "master" CloudFormation stack.
 
+In comparison to CloudFormation nested Stacks, it offers the following additional functionalities:
+* Cross-Region
+* Cross-Account
+
 ![CrossStack Architecture](_images/architecture.drawio.png)
 
 Some real world examples include:
@@ -36,11 +40,17 @@ Properties:
   CfnCapabilities:
   - Array
   CfnParameters:
-    Object
+    Parameter
   CfnStackName: String
   CfnTemplate: String
+  CfnTemplateUrl: String
   LogLevel: Number
   Region: String
+```
+
+Parameter Object
+```yml
+ParameterKey: ParamterValue
 ```
 
 ## Properties
@@ -124,8 +134,20 @@ CfnStackName
 CfnTemplate
 
 > CloudFormation Stack template for CrossStack's installation.
+> You must include either CfnTemplateUrl or CfnTemplateBody in a Stack, but you cannot use both.
 >
-> _Required_: Yes
+> _Required_: No
+>
+> _Type_: String
+> 
+> _Update allowed_: Yes
+
+CfnTemplateUrl
+
+> CloudFormation Stack template S3 url for CrossStack's installation.
+> You must include either CfnTemplateUrl or CfnTemplateBody in a Stack, but you cannot use both.
+>
+> _Required_: No
 >
 > _Type_: String
 > 

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,6 +20,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
         "<a href="#cfncapabilities" title="CfnCapabilities">CfnCapabilities</a>" : <i>[ String, ... ]</i>,
         "<a href="#cfnparameters" title="CfnParameters">CfnParameters</a>" : <i>Map</i>,
         "<a href="#cfntemplate" title="CfnTemplate">CfnTemplate</a>" : <i>String</i>,
+        "<a href="#cfntemplateurl" title="CfnTemplateUrl">CfnTemplateUrl</a>" : <i>String</i>,
         "<a href="#loglevel" title="LogLevel">LogLevel</a>" : <i>Integer</i>
     }
 }
@@ -39,6 +40,7 @@ Properties:
       - String</i>
     <a href="#cfnparameters" title="CfnParameters">CfnParameters</a>: <i>Map</i>
     <a href="#cfntemplate" title="CfnTemplate">CfnTemplate</a>: <i>String</i>
+    <a href="#cfntemplateurl" title="CfnTemplateUrl">CfnTemplateUrl</a>: <i>String</i>
     <a href="#loglevel" title="LogLevel">LogLevel</a>: <i>Integer</i>
 </pre>
 
@@ -110,7 +112,15 @@ _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormati
 
 #### CfnTemplate
 
-_Required_: Yes
+_Required_: No
+
+_Type_: String
+
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+
+#### CfnTemplateUrl
+
+_Required_: No
 
 _Type_: String
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -19,7 +19,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
         "<a href="#cfnstackname" title="CfnStackName">CfnStackName</a>" : <i>String</i>,
         "<a href="#cfncapabilities" title="CfnCapabilities">CfnCapabilities</a>" : <i>[ String, ... ]</i>,
         "<a href="#cfnparameters" title="CfnParameters">CfnParameters</a>" : <i>Map</i>,
-        "<a href="#cfntemplate" title="CfnTemplate">CfnTemplate</a>" : <i>Map</i>,
+        "<a href="#cfntemplate" title="CfnTemplate">CfnTemplate</a>" : <i>String</i>,
         "<a href="#loglevel" title="LogLevel">LogLevel</a>" : <i>Integer</i>
     }
 }
@@ -38,7 +38,7 @@ Properties:
     <a href="#cfncapabilities" title="CfnCapabilities">CfnCapabilities</a>: <i>
       - String</i>
     <a href="#cfnparameters" title="CfnParameters">CfnParameters</a>: <i>Map</i>
-    <a href="#cfntemplate" title="CfnTemplate">CfnTemplate</a>: <i>Map</i>
+    <a href="#cfntemplate" title="CfnTemplate">CfnTemplate</a>: <i>String</i>
     <a href="#loglevel" title="LogLevel">LogLevel</a>: <i>Integer</i>
 </pre>
 
@@ -60,7 +60,7 @@ _Required_: Yes
 
 _Type_: String
 
-_Pattern_: <code>^[a-z]+-[a-z]-[0-9]+$</code>
+_Pattern_: <code>^[a-z]+-[a-z]+-[0-9]+$</code>
 
 _Update requires_: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
 
@@ -72,7 +72,7 @@ _Type_: String
 
 _Pattern_: <code>^/.*/$</code>
 
-_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+_Update requires_: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
 
 #### AssumeRoleName
 
@@ -80,7 +80,7 @@ _Required_: Yes
 
 _Type_: String
 
-_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+_Update requires_: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
 
 #### CfnStackName
 
@@ -98,8 +98,6 @@ _Required_: No
 
 _Type_: List of String
 
-_Allowed Values_: <code>CAPABILITY_IAM</code> | <code>CAPABILITY_NAMED_IAM</code> | <code>CAPABILITY_AUTO_EXPAND</code>
-
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 
 #### CfnParameters
@@ -114,7 +112,7 @@ _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormati
 
 _Required_: Yes
 
-_Type_: Map
+_Type_: String
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 
@@ -128,7 +126,7 @@ _Type_: Integer
 
 _Allowed Values_: <code>0</code> | <code>10</code> | <code>20</code> | <code>30</code> | <code>40</code> | <code>50</code>
 
-_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+_Update requires_: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
 
 ## Return Values
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -48,7 +48,7 @@ Properties:
 
 #### AccountId
 
-_Required_: Yes
+_Required_: No
 
 _Type_: String
 
@@ -58,7 +58,7 @@ _Update requires_: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/l
 
 #### Region
 
-_Required_: Yes
+_Required_: No
 
 _Type_: String
 
@@ -78,7 +78,7 @@ _Update requires_: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/l
 
 #### AssumeRoleName
 
-_Required_: Yes
+_Required_: No
 
 _Type_: String
 
@@ -86,7 +86,7 @@ _Update requires_: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/l
 
 #### CfnStackName
 
-_Required_: Yes
+_Required_: No
 
 _Type_: String
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -100,6 +100,8 @@ _Required_: No
 
 _Type_: List of String
 
+_Allowed Values_: [<code>CAPABILITY_IAM</code>, <code>CAPABILITY_NAMED_IAM</code>, <code>CAPABILITY_AUTO_EXPAND</code>]
+
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 
 #### CfnParameters

--- a/docs/README.md
+++ b/docs/README.md
@@ -48,7 +48,7 @@ Properties:
 
 #### AccountId
 
-_Required_: No
+_Required_: Yes
 
 _Type_: String
 
@@ -58,7 +58,7 @@ _Update requires_: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/l
 
 #### Region
 
-_Required_: No
+_Required_: Yes
 
 _Type_: String
 
@@ -78,7 +78,7 @@ _Update requires_: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/l
 
 #### AssumeRoleName
 
-_Required_: No
+_Required_: Yes
 
 _Type_: String
 
@@ -86,7 +86,7 @@ _Update requires_: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/l
 
 #### CfnStackName
 
-_Required_: No
+_Required_: Yes
 
 _Type_: String
 
@@ -112,6 +112,8 @@ _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormati
 
 #### CfnTemplate
 
+You must include either CfnTemplateUrl or CfnTemplateBody in a Stack, but you cannot use both.
+
 _Required_: No
 
 _Type_: String
@@ -119,6 +121,8 @@ _Type_: String
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 
 #### CfnTemplateUrl
+
+You must include either CfnTemplateUrl or CfnTemplateBody in a Stack, but you cannot use both.
 
 _Required_: No
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-cloudformation-cli-python-lib==2.0.0
+cloudformation-cli-python-lib>=2.1.3

--- a/resource-role.yaml
+++ b/resource-role.yaml
@@ -7,7 +7,7 @@ Resources:
   ExecutionRole:
     Type: AWS::IAM::Role
     Properties:
-      MaxSessionDuration: 8400
+      MaxSessionDuration: 21000
       AssumeRolePolicyDocument:
         Version: '2012-10-17'
         Statement:

--- a/samples/ssm-example.yml
+++ b/samples/ssm-example.yml
@@ -1,0 +1,36 @@
+AWSTemplateFormatVersion: "2010-09-09"
+
+# aws cloudformation deploy --template-file samples/ssm-example.yml --stack-name test
+
+Resources:
+  TestResource:
+    Type: SPRT::CrossStack::Executor
+    Properties:
+      AccountId: 123456789123
+      Region: eu-west-1
+      LogLevel: 10
+      CfnCapabilities:
+      - CAPABILITY_NAMED_IAM
+      AssumeRoleName: x-account-role
+      CfnStackName: my-first-test-stack
+      CfnParameters:
+        TestInput: myTestStack
+      CfnTemplate: |
+        AWSTemplateFormatVersion: "2010-09-09"
+        Parameters:
+          TestInput:
+            Type: String
+        Resources:
+          SomeResource:
+            Type: AWS::SSM::Parameter
+            Properties:
+              Name: !Sub /my/stack/${TestInput}
+              Type: String
+              Value: DUMMY
+        Outputs:
+          TestOutput:
+            Value: !Ref SomeResource
+
+Outputs:
+  TestOut:
+    Value: !GetAtt TestResource.CfnStackOutput1

--- a/sprt-crossstack-executor.json
+++ b/sprt-crossstack-executor.json
@@ -37,6 +37,9 @@
     "CfnTemplate": {
       "type": "string"
     },
+    "CfnTemplateUrl": {
+      "type": "string"
+    },
     "CfnStackId": {
       "type": "string"
     },
@@ -104,7 +107,6 @@
     "AccountId",
     "Region",
     "AssumeRoleName",
-    "CfnTemplate",
     "CfnStackName"
   ],
   "createOnlyProperties": [

--- a/sprt-crossstack-executor.json
+++ b/sprt-crossstack-executor.json
@@ -10,7 +10,7 @@
     },
     "Region": {
       "type": "string",
-      "pattern": "^[a-z]+-[a-z]-[0-9]+$"
+      "pattern": "^[a-z]+-[a-z]+-[0-9]+$"
     },
     "AssumeRolePath": {
       "type": "string",
@@ -25,17 +25,17 @@
     "CfnCapabilities": {
       "type": "array",
       "description": "Set the capability permissions for execution. Can be left out or contains one or more of the following Capabilities: https://docs.aws.amazon.com/AWSCloudFormation/latest/APIReference/API_CreateStack.html#API_CreateStack_RequestParameters",
-      "enum": ["CAPABILITY_IAM", "CAPABILITY_NAMED_IAM", "CAPABILITY_AUTO_EXPAND"],
-      "uniqueItems": true,
       "items": {
-        "type": "string"
+        "enum": ["CAPABILITY_IAM", "CAPABILITY_NAMED_IAM", "CAPABILITY_AUTO_EXPAND"],
+        "type": "string",
+        "uniqueItems": true
       }
     },
     "CfnParameters": {
       "type": "object"
     },
     "CfnTemplate": {
-      "type": "object"
+      "type": "string"
     },
     "CfnStackId": {
       "type": "string"
@@ -70,8 +70,8 @@
     "LogLevel": {
       "type": "integer",
       "description": "Set the log level for execution. Can be one of Python's integer log values: https://docs.python.org/3/library/logging.html#logging-levels",
-      "enum": ["0", "10", "20", "30", "40", "50"],
-      "default": "30"
+      "enum": [0, 10, 20, 30, 40, 50],
+      "default": 30
     }
   },
   "handlers": {
@@ -110,7 +110,10 @@
   "createOnlyProperties": [
     "/properties/AccountId",
     "/properties/Region",
-    "/properties/CfnStackName"
+    "/properties/CfnStackName",
+    "/properties/AssumeRolePath",
+    "/properties/AssumeRoleName",
+    "/properties/LogLevel"
   ],
   "readOnlyProperties": [
     "/properties/CfnStackId",

--- a/sprt-crossstack-executor.json
+++ b/sprt-crossstack-executor.json
@@ -106,11 +106,25 @@
     "/properties/CfnStackId",
     "/properties/LogLevel"
   ],
-  "required": [
-    "AccountId",
-    "Region",
-    "AssumeRoleName",
-    "CfnStackName"
+  "oneOf": [
+    {
+      "required": [
+        "AccountId",
+        "Region",
+        "AssumeRoleName",
+        "CfnStackName",
+        "CfnTemplate"
+      ]
+    },
+    {
+      "required": [
+        "AccountId",
+        "Region",
+        "AssumeRoleName",
+        "CfnStackName",
+        "CfnTemplateUrl"
+      ]
+    }
   ],
   "createOnlyProperties": [
     "/properties/AccountId",

--- a/sprt-crossstack-executor.json
+++ b/sprt-crossstack-executor.json
@@ -79,16 +79,19 @@
   },
   "handlers": {
     "create": {
-      "permissions": ["sts:AssumeRole"]
+      "permissions": ["sts:AssumeRole"],
+      "timeoutInMinutes": 300
     },
     "read": {
       "permissions": ["sts:AssumeRole"]
     },
     "update": {
-      "permissions": ["sts:AssumeRole"]
+      "permissions": ["sts:AssumeRole"],
+      "timeoutInMinutes": 300
     },
     "delete": {
-      "permissions": ["sts:AssumeRole"]
+      "permissions": ["sts:AssumeRole"],
+      "timeoutInMinutes": 300
     },
     "list": {
       "permissions": ["sts:AssumeRole"]

--- a/src/sprt_crossstack_executor/handlers.py
+++ b/src/sprt_crossstack_executor/handlers.py
@@ -45,9 +45,9 @@ def create_handler(
         callbackDelaySeconds=10
     )
 
-    model.AssumeRolePath  = "/" if model.AssumeRolePath is None else model.AssumeRolePath
+    model.AssumeRolePath = "/" if model.AssumeRolePath is None else model.AssumeRolePath
     model.LogLevel = logging.WARNING if model.LogLevel is None else model.LogLevel
-    
+
     LOG.setLevel(model.LogLevel)
     _log_parameters(model, callback_context)
 
@@ -73,7 +73,7 @@ def update_handler(
         callbackDelaySeconds=10
     )
 
-    model.AssumeRolePath  = "/" if model.AssumeRolePath is None else model.AssumeRolePath
+    model.AssumeRolePath = "/" if model.AssumeRolePath is None else model.AssumeRolePath
     model.LogLevel = logging.WARNING if model.LogLevel is None else model.LogLevel
 
     LOG.setLevel(model.LogLevel)
@@ -93,7 +93,7 @@ def delete_handler(
     request: ResourceHandlerRequest,
     callback_context: MutableMapping[str, Any]
 ) -> ProgressEvent:
-    
+
     model = request.desiredResourceState
     progress: ProgressEvent = ProgressEvent(
         status=OperationStatus.IN_PROGRESS,
@@ -101,6 +101,8 @@ def delete_handler(
         callbackContext=callback_context,
         callbackDelaySeconds=10
     )
+    model.AssumeRolePath = "/" if model.AssumeRolePath is None else model.AssumeRolePath
+    model.LogLevel = logging.WARNING if model.LogLevel is None else model.LogLevel
 
     LOG.setLevel(model.LogLevel)
     _log_parameters(model, callback_context)
@@ -119,7 +121,7 @@ def read_handler(
     request: ResourceHandlerRequest,
     callback_context: MutableMapping[str, Any]
 ) -> ProgressEvent:
-    
+
     LOG.error(request)
 
     model = request.desiredResourceState
@@ -129,6 +131,8 @@ def read_handler(
         callbackContext=callback_context,
         callbackDelaySeconds=10
     )
+    model.AssumeRolePath = "/" if model.AssumeRolePath is None else model.AssumeRolePath
+    model.LogLevel = logging.WARNING if model.LogLevel is None else model.LogLevel
 
     LOG.setLevel(model.LogLevel)
     LOG.info("Entering read.handle() method.")

--- a/src/sprt_crossstack_executor/models.py
+++ b/src/sprt_crossstack_executor/models.py
@@ -47,6 +47,7 @@ class ResourceModel(BaseModel):
     CfnCapabilities: Optional[Sequence[str]]
     CfnParameters: Optional[MutableMapping[str, Any]]
     CfnTemplate: Optional[str]
+    CfnTemplateUrl: Optional[str]
     CfnStackId: Optional[str]
     CfnStackOutput1: Optional[str]
     CfnStackOutput2: Optional[str]
@@ -77,6 +78,7 @@ class ResourceModel(BaseModel):
             CfnCapabilities=json_data.get("CfnCapabilities"),
             CfnParameters=json_data.get("CfnParameters"),
             CfnTemplate=json_data.get("CfnTemplate"),
+            CfnTemplateUrl=json_data.get("CfnTemplateUrl"),
             CfnStackId=json_data.get("CfnStackId"),
             CfnStackOutput1=json_data.get("CfnStackOutput1"),
             CfnStackOutput2=json_data.get("CfnStackOutput2"),

--- a/src/sprt_crossstack_executor/models.py
+++ b/src/sprt_crossstack_executor/models.py
@@ -46,7 +46,7 @@ class ResourceModel(BaseModel):
     CfnStackName: Optional[str]
     CfnCapabilities: Optional[Sequence[str]]
     CfnParameters: Optional[MutableMapping[str, Any]]
-    CfnTemplate: Optional[MutableMapping[str, Any]]
+    CfnTemplate: Optional[str]
     CfnStackId: Optional[str]
     CfnStackOutput1: Optional[str]
     CfnStackOutput2: Optional[str]

--- a/src/sprt_crossstack_executor/sub_handlers/create.py
+++ b/src/sprt_crossstack_executor/sub_handlers/create.py
@@ -41,7 +41,7 @@ def handle(
 def _create_stack(cfn_client, model: ResourceModel):
     capabilities = [] if model.CfnCapabilities is None else model.CfnCapabilities
 
-    cfn_input_parameters = [] if model.CfnParameters is None else model.CfnParameters
+    cfn_input_parameters = {} if model.CfnParameters is None else model.CfnParameters
     final_parameters = []
     for key, value in cfn_input_parameters.items():
         final_parameters.append({

--- a/src/sprt_crossstack_executor/sub_handlers/create.py
+++ b/src/sprt_crossstack_executor/sub_handlers/create.py
@@ -94,8 +94,8 @@ def _is_create_complete(cfn_client, model: ResourceModel):
 
     stack_status = describe_response["Stacks"][0]["StackStatus"]
     if stack_status.endswith("_FAILED") or stack_status.endswith("ROLLBACK_COMPLETE"):
-        raise Exception("StackStatus={}, StackStatusReason={}".format(stack_status, describe_response["Stacks"][0]("StackStatusReason")))
-    elif stack_status in ["CREATE_COMPLETE", "UPDATE_COMPLETE"]:
+        raise Exception("StackStatus={}, StackStatusReason={}".format(stack_status, describe_response["Stacks"][0]["StackStatusReason"]))
+    elif stack_status in ["CREATE_COMPLETE", "UPDATE_COMPLETE", "IMPORT_COMPLETE"]:
         return True
     else:
         return False

--- a/src/sprt_crossstack_executor/sub_handlers/create.py
+++ b/src/sprt_crossstack_executor/sub_handlers/create.py
@@ -75,6 +75,7 @@ def _create_stack(cfn_client, model: ResourceModel):
     else:
         request['TemplateBody'] = model.CfnTemplate
 
+    # For importing existing stacks into this resources a create request performs an update as well
     if not stack_exists:
         cfn_client.create_stack(**request)
     else:

--- a/src/sprt_crossstack_executor/sub_handlers/create.py
+++ b/src/sprt_crossstack_executor/sub_handlers/create.py
@@ -93,7 +93,7 @@ def _is_create_complete(cfn_client, model: ResourceModel):
     )
 
     stack_status = describe_response["Stacks"][0]["StackStatus"]
-    if stack_status.endswith("_FAILED"):
+    if stack_status.endswith("_FAILED") or stack_status.endswith("ROLLBACK_COMPLETE"):
         raise Exception("StackStatus={}, StackStatusReason={}".format(stack_status, describe_response["Stacks"][0]("StackStatusReason")))
     elif stack_status in ["CREATE_COMPLETE", "UPDATE_COMPLETE"]:
         return True

--- a/src/sprt_crossstack_executor/sub_handlers/delete.py
+++ b/src/sprt_crossstack_executor/sub_handlers/delete.py
@@ -54,10 +54,6 @@ def _delete_stack(cfn_client, model: ResourceModel):
         StackName=model.CfnStackName
     )
 
-    # waiter = cfn_client.get_waiter("stack_delete_complete")
-    #
-    # waiter.wait(StackName=model.CfnStackName)
-
 
 def _is_delete_complete(cfn_client, callback_context: MutableMapping[str, Any]):
     describe_response = cfn_client.describe_stacks(

--- a/src/sprt_crossstack_executor/sub_handlers/delete.py
+++ b/src/sprt_crossstack_executor/sub_handlers/delete.py
@@ -62,7 +62,7 @@ def _is_delete_complete(cfn_client, callback_context: MutableMapping[str, Any]):
 
     stack_status = describe_response["Stacks"][0]["StackStatus"]
     if stack_status.endswith("_FAILED"):
-        raise Exception("StackStatus={}, StackStatusReason={}".format(stack_status, describe_response["Stacks"][0]("StackStatusReason")))
+        raise Exception("StackStatus={}, StackStatusReason={}".format(stack_status, describe_response["Stacks"][0]["StackStatusReason"]))
     elif stack_status == "DELETE_COMPLETE":
         return True
     else:

--- a/src/sprt_crossstack_executor/sub_handlers/read.py
+++ b/src/sprt_crossstack_executor/sub_handlers/read.py
@@ -23,10 +23,9 @@ def handle(
 ):
     model = request.desiredResourceState
     LOG.setLevel(model.LogLevel)
-    
+
     cfn_client = utils.get_cross_cfn_client(session, model, "ReadHandler")
     _set_output_values(cfn_client, model)
-    
 
     progress.status = OperationStatus.SUCCESS
 
@@ -35,16 +34,16 @@ def _set_output_values(cfn_client, model: ResourceModel):
     describe_response = cfn_client.describe_stacks(
         StackName=model.CfnStackName
     )
-    
+
     outputs = describe_response["Stacks"][0]["Outputs"]
 
     index = 1
     for output in outputs:
         if index == 10:
             raise Exception("Only 9 output variables are created so far.")
-            
+
         setattr(model, f"CfnStackOutput{index}", output["OutputValue"])
         index += 1
-        
-    
+
+
     LOG.debug("Following variables were defined (CfnStackOutput*): %s", model)

--- a/src/sprt_crossstack_executor/sub_handlers/read.py
+++ b/src/sprt_crossstack_executor/sub_handlers/read.py
@@ -35,7 +35,7 @@ def _set_output_values(cfn_client, model: ResourceModel):
         StackName=model.CfnStackName
     )
 
-    outputs = describe_response["Stacks"][0]["Outputs"]
+    outputs = [] if 'Outputs' not in describe_response["Stacks"][0] else describe_response["Stacks"][0]["Outputs"]
 
     index = 1
     for output in outputs:

--- a/src/sprt_crossstack_executor/sub_handlers/update.py
+++ b/src/sprt_crossstack_executor/sub_handlers/update.py
@@ -76,8 +76,8 @@ def _is_update_complete(cfn_client, model: ResourceModel):
 
     stack_status = describe_response["Stacks"][0]["StackStatus"]
     if stack_status.endswith("_FAILED") or stack_status.endswith("ROLLBACK_COMPLETE"):
-        raise Exception("StackStatus={}, StackStatusReason={}".format(stack_status, describe_response["Stacks"][0]("StackStatusReason")))
-    elif stack_status in ["UPDATE_COMPLETE", "CREATE_COMPLETE"]:
+        raise Exception("StackStatus={}, StackStatusReason={}".format(stack_status, describe_response["Stacks"][0]["StackStatusReason"]))
+    elif stack_status in ["UPDATE_COMPLETE", "CREATE_COMPLETE", "IMPORT_COMPLETE"]:
         return True
     else:
         return False

--- a/src/sprt_crossstack_executor/sub_handlers/update.py
+++ b/src/sprt_crossstack_executor/sub_handlers/update.py
@@ -75,7 +75,7 @@ def _is_update_complete(cfn_client, model: ResourceModel):
     )
 
     stack_status = describe_response["Stacks"][0]["StackStatus"]
-    if stack_status.endswith("_FAILED"):
+    if stack_status.endswith("_FAILED") or stack_status.endswith("ROLLBACK_COMPLETE"):
         raise Exception("StackStatus={}, StackStatusReason={}".format(stack_status, describe_response["Stacks"][0]("StackStatusReason")))
     elif stack_status in ["UPDATE_COMPLETE", "CREATE_COMPLETE"]:
         return True

--- a/src/sprt_crossstack_executor/sub_handlers/update.py
+++ b/src/sprt_crossstack_executor/sub_handlers/update.py
@@ -21,17 +21,17 @@ def handle(
     progress: ProgressEvent
 ):
     model = request.desiredResourceState
-    
+
     LOG.setLevel(model.LogLevel)
     LOG.info("Entering update.handle() method.")
-    
+
     cfn_client = utils.get_cross_cfn_client(session, model, "UpdateHandler")
-    
+
     if not callback_context.get("UPDATE_STARTED"):
         model.CfnStackId = "{}-{}-{}".format(model.CfnStackName, model.AccountId, model.Region)
         _update_stack(cfn_client, model)
         callback_context["UPDATE_STARTED"] = True
-    
+
     if _is_update_complete(cfn_client, model):
         progress.status = OperationStatus.SUCCESS
 
@@ -43,7 +43,7 @@ def _update_stack(cfn_client, model: ResourceModel):
 
     cfn_input_parameters = [] if model.CfnParameters is None else model.CfnParameters
     final_parameters = []
-    for key, value in model.CfnParameters.items():
+    for key, value in cfn_input_parameters.items():
         final_parameters.append({
             "ParameterKey": key,
             "ParameterValue": value
@@ -55,13 +55,13 @@ def _update_stack(cfn_client, model: ResourceModel):
         Parameters=final_parameters,
         Capabilities=capabilities
     )
-    
-    
+
+
 def _is_update_complete(cfn_client, model: ResourceModel):
     describe_response = cfn_client.describe_stacks(
         StackName=model.CfnStackName
     )
-    
+
     stack_status = describe_response["Stacks"][0]["StackStatus"]
     if stack_status.endswith("_FAILED"):
         raise Exception("StackStatus={}, StackStatusReason={}".format(stack_status, describe_response["Stacks"][0]("StackStatusReason")))

--- a/src/sprt_crossstack_executor/sub_handlers/update.py
+++ b/src/sprt_crossstack_executor/sub_handlers/update.py
@@ -41,7 +41,7 @@ def handle(
 def _update_stack(cfn_client, model: ResourceModel):
     capabilities = [] if model.CfnCapabilities is None else model.CfnCapabilities
 
-    cfn_input_parameters = [] if model.CfnParameters is None else model.CfnParameters
+    cfn_input_parameters = {} if model.CfnParameters is None else model.CfnParameters
     final_parameters = []
     for key, value in cfn_input_parameters.items():
         final_parameters.append({

--- a/src/sprt_crossstack_executor/sub_handlers/utils.py
+++ b/src/sprt_crossstack_executor/sub_handlers/utils.py
@@ -24,9 +24,9 @@ def _get_cross_session(session: SessionProxy, model: ResourceModel, session_name
     :return: Can be used to obtain session.client() or session.resource()
     """
     LOG.setLevel(model.LogLevel)
-    
+
     role_arn = "arn:aws:iam::{}:role{}{}".format(model.AccountId, model.AssumeRolePath, model.AssumeRoleName)
-    
+
     LOG.debug("Assuming Cross session role: %s", role_arn)
     assumed_role = session.client("sts").assume_role(
         RoleArn=role_arn,
@@ -38,6 +38,5 @@ def _get_cross_session(session: SessionProxy, model: ResourceModel, session_name
         aws_secret_access_key=assumed_role["Credentials"]["SecretAccessKey"],
         aws_session_token=assumed_role["Credentials"]["SessionToken"]
     )
-
 
     return session

--- a/test/test-invoke.json
+++ b/test/test-invoke.json
@@ -1,17 +1,13 @@
 {
+  "clientRequestToken": "ecba020e-b2e6-4742-a7d0-8a06ae7c4b2b",
   "desiredResourceState": {
-    "AccountId": "123456789012",
-    "Region": "eu-central-1",
-    "CfnTemplate": {
-      "AWSTemplateFormatVersion": "2010-09-09",
-      "Resources": {
-        "SomeResource": {
-          "Type": "AWS::S3::Bucket",
-          "Properties": {
-            "BucketName": "!Sub Some-bucket-name-${!AWS::AccountId}-${!AWS::Region}"
-          }
-        }
-      }
-    }
-  }
+    "AccountId": "123456789123",
+    "Region": "eu-west-1",
+    "AssumeRoleName": "x-account-role",
+    "CfnStackName": "testStack",
+    "LogLevel": 10,
+    "CfnTemplate": "{\"AWSTemplateFormatVersion\":\"2010-09-09\",\"Resources\":{\"SomeResource\":{\"Type\":\"AWS::SSM::Parameter\",\"Properties\":{\"Value\":\"DUMMY\",\"Type\":\"String\",\"Name\":\"/my/stack/test\"}}}}"
+  },
+  "previousResourceState": null,
+  "logicalResourceIdentifier": null
 }


### PR DESCRIPTION
* New CFN Py Plugin Version
* minor fixes (usage of wrong variable, casting errors, invoke test issues)
* Finally adapted code to template as string not object (reason see below)
* Removed `waiter` in delete handler, rather then wait for the stack being deleted (which can break deletion on long running operations), rely on callback


#### Why cross-account template as string?
Passing the template as object has benefits, such as syntax highlighting, auto-intention, etc. But one major issue is, CloudFormation will handle intrinsic functions as part of the wrapping template. This leads to issues for example with `!Ref`. Those are picked from the wrapping template, which of course fails.

Secondly it leads to error when parsing in python, had that in the past in other projects. The yaml syntax is not always readable by pythons yaml lib.

To be even more in line with most of the cfn resources i added s3 url template option